### PR TITLE
Stamping Stable Genius

### DIFF
--- a/build_tools/workspace-status
+++ b/build_tools/workspace-status
@@ -18,7 +18,7 @@ fi
 
 echo "CURRENT_TIME $builddate"
 echo "CURRENT_EPOCH $buildepoch"
-echo "GIT_COMMIT $gitcommit"
-echo "GIT_VERSION $version"
-echo "GIT_BRANCH $gitbranch"
+echo "STABLE_GIT_VERSION $version"
+echo "STABLE_GIT_BRANCH $gitbranch"
+echo "STABLE_GIT_COMMIT $gitcommit"
 echo "STABLE_PLATFORM $platform"

--- a/lib/builddata/BUILD.bazel
+++ b/lib/builddata/BUILD.bazel
@@ -6,9 +6,9 @@ go_library(
     importpath = "github.com/nugget/phoebot/lib/builddata",
     visibility = ["//visibility:public"],
     x_defs = {
-        "VERSION": "{GIT_VERSION}",
-        "GITBRANCH": "{GIT_BRANCH}",
-        "GITCOMMIT": "{GIT_COMMIT}",
+        "VERSION": "{STABLE_GIT_VERSION}",
+        "GITBRANCH": "{STABLE_GIT_BRANCH}",
+        "GITCOMMIT": "{STABLE_GIT_COMMIT}",
         "GOVERSION": "{STABLE_BASEL_VERSION}",
         "BUILDENV": "{STABLE_PLATFORM}",
         "BUILDEPOCH_STR": "{BUILD_TIMESTAMP}",


### PR DESCRIPTION
Switches the GIT-related stamping values to be `STABLE_` which forces the `builddata` target to be rebuilt every time.  Without this, we end up with stale version information in the uname/status output.