### PR TITLE
Add an ignores list to segregate dev from production

### DIFF
--- a/db/deploy/ignore.sql
+++ b/db/deploy/ignore.sql
@@ -1,0 +1,19 @@
+-- Deploy phoebot:ignore to pg
+
+BEGIN;
+
+    CREATE TABLE ignore (
+        ignoreID uuid NOT NULL DEFAULT gen_random_uuid(),
+        added timestamp(0) NOT NULL DEFAULT current_timestamp,
+        changed timestamp(0) NOT NULL DEFAULT current_timestamp,
+        deleted timestamp(0),
+        enabled boolean NOT NULL DEFAULT TRUE,
+        category varchar NOT NULL,
+        target varchar NOT NULL,
+        description varchar NOT NULL DEFAULT '',
+        PRIMARY KEY(ignoreID)
+    );
+    CREATE TRIGGER onupdate BEFORE UPDATE ON ignore FOR EACH ROW EXECUTE PROCEDURE onupdate_changed();
+    GRANT SELECT, INSERT, UPDATE ON ignore TO phoebot;
+
+COMMIT;

--- a/db/revert/ignore.sql
+++ b/db/revert/ignore.sql
@@ -1,0 +1,7 @@
+-- Revert phoebot:ignore from pg
+
+BEGIN;
+
+    DROP TABLE ignore;
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -7,3 +7,4 @@ initdb 2019-05-26T21:25:44Z David McNett <nugget@nigeru.nuggethaus.net> # Initia
 playerdetails 2019-05-27T18:05:33Z David McNett <nugget@nigeru.nuggethaus.net> # Extras for player table
 discordlogs 2019-05-27T18:37:30Z David McNett <nugget@nigeru.nuggethaus.net> # Tables to track discord activity
 mojangreleases 2019-05-28T01:44:03Z David McNett <nugget@nigeru.nuggethaus.net> # Table to track mojang releases
+ignore 2019-05-29T02:26:39Z David McNett <nugget@nigeru.nuggethaus.net> # Add an ignore list table

--- a/db/verify/ignore.sql
+++ b/db/verify/ignore.sql
@@ -1,0 +1,7 @@
+-- Verify phoebot:ignore on pg
+
+BEGIN;
+
+    SELECT 1 FROM ignore LIMIT 1;
+
+ROLLBACK;

--- a/lib/phoelib/BUILD.bazel
+++ b/lib/phoelib/BUILD.bazel
@@ -5,5 +5,9 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/nugget/phoebot/lib/phoelib",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/github.com/sirupsen/logrus:go_default_library"],
+    deps = [
+        "//lib/db:go_default_library",
+        "//vendor/github.com/bwmarrin/discordgo:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
 )


### PR DESCRIPTION
Allow the bot process to ignore specified players, channels, or guilds.  This allows us to separate development and production activities.  This closes #4 