### PR TITLE
Parse Mojang date as full month if abbreviation fails

### DIFF
--- a/products/mojang/main.go
+++ b/products/mojang/main.go
@@ -167,6 +167,9 @@ func ArticleFromJSON(json string) (a models.Article, err error) {
 
 	publishedString := gjson.Get(json, "publish_date").String()
 	a.PublishDate, err = time.Parse("02 Jan 2006 15:04:05 MST", publishedString)
+	if err != nil {
+		a.PublishDate, err = time.Parse("02 January 2006 15:04:05 MST", publishedString)
+	}
 
 	return a, err
 }


### PR DESCRIPTION
I was seeing parse errors from the mojang news feed.  It looks like some of the articles posted are using a full month name, not an abbreviation.  So now if the first parse fails, we try again looking for a full month name.

> `error="parsing time "03 June 2019 15:14:53 UTC" as "02 Jan 2006 15:04:05 MST"`