### PR TITLE
Add feature flag toggles for the various product pollers

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -124,13 +124,6 @@ go_repository(
 )
 
 go_repository(
-    name = "com_github_burntsushi_xgb",
-    importpath = "github.com/BurntSushi/xgb",
-    sum = "h1:1BDTz0u9nC3//pOCMdNH+CiXJVYJh5UQNCOBG7jbELc=",
-    version = "v0.0.0-20160522181843-27f122750802",
-)
-
-go_repository(
     name = "com_github_bwmarrin_discordgo",
     importpath = "github.com/bwmarrin/discordgo",
     sum = "h1:nA7jiTtqUA9lT93WL2jPjUp8ZTEInRujBdx1C9gkr20=",
@@ -299,38 +292,10 @@ go_repository(
 )
 
 go_repository(
-    name = "com_github_google_martian",
-    importpath = "github.com/google/martian",
-    sum = "h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=",
-    version = "v2.1.0+incompatible",
-)
-
-go_repository(
-    name = "com_github_google_pprof",
-    importpath = "github.com/google/pprof",
-    sum = "h1:Jnx61latede7zDD3DiiP4gmNz33uK0U5HDUaF0a/HVQ=",
-    version = "v0.0.0-20190515194954-54271f7e092f",
-)
-
-go_repository(
-    name = "com_github_google_renameio",
-    importpath = "github.com/google/renameio",
-    sum = "h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=",
-    version = "v0.1.0",
-)
-
-go_repository(
     name = "com_github_google_uuid",
     importpath = "github.com/google/uuid",
     sum = "h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=",
     version = "v1.1.1",
-)
-
-go_repository(
-    name = "com_github_googleapis_gax_go_v2",
-    importpath = "github.com/googleapis/gax-go/v2",
-    sum = "h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=",
-    version = "v2.0.5",
 )
 
 go_repository(
@@ -362,13 +327,6 @@ go_repository(
 )
 
 go_repository(
-    name = "com_github_hashicorp_golang_lru",
-    importpath = "github.com/hashicorp/golang-lru",
-    sum = "h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=",
-    version = "v0.5.1",
-)
-
-go_repository(
     name = "com_github_hashicorp_hcl",
     importpath = "github.com/hashicorp/hcl",
     sum = "h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=",
@@ -380,20 +338,6 @@ go_repository(
     importpath = "github.com/jonboulle/clockwork",
     sum = "h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=",
     version = "v0.1.0",
-)
-
-go_repository(
-    name = "com_github_json_iterator_go",
-    importpath = "github.com/json-iterator/go",
-    sum = "h1:MrUvLMLTMxbqFJ9kzlvat/rYZqZnW3u4wkLzWTaFwKs=",
-    version = "v1.1.6",
-)
-
-go_repository(
-    name = "com_github_jstemmer_go_junit_report",
-    importpath = "github.com/jstemmer/go-junit-report",
-    sum = "h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=",
-    version = "v0.0.0-20190106144839-af01ea7f8024",
 )
 
 go_repository(
@@ -481,20 +425,6 @@ go_repository(
 )
 
 go_repository(
-    name = "com_github_modern_go_concurrent",
-    importpath = "github.com/modern-go/concurrent",
-    sum = "h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=",
-    version = "v0.0.0-20180306012644-bacd9c7ef1dd",
-)
-
-go_repository(
-    name = "com_github_modern_go_reflect2",
-    importpath = "github.com/modern-go/reflect2",
-    sum = "h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=",
-    version = "v1.0.1",
-)
-
-go_repository(
     name = "com_github_mwitkow_go_conntrack",
     importpath = "github.com/mwitkow/go-conntrack",
     sum = "h1:F9x/1yl3T2AeKLr2AMdilSD8+f9bvMnNN8VS5iDtovc=",
@@ -576,20 +506,6 @@ go_repository(
     importpath = "github.com/rogpeppe/fastuuid",
     sum = "h1:gu+uRPtBe88sKxUCEXRoeCvVG90TJmwhiqRpvdhQFng=",
     version = "v0.0.0-20150106093220-6724a57986af",
-)
-
-go_repository(
-    name = "com_github_rogpeppe_go_internal",
-    importpath = "github.com/rogpeppe/go-internal",
-    sum = "h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=",
-    version = "v1.3.0",
-)
-
-go_repository(
-    name = "com_github_satori_go_uuid",
-    importpath = "github.com/satori/go.uuid",
-    sum = "h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=",
-    version = "v1.2.0",
 )
 
 go_repository(
@@ -754,13 +670,6 @@ go_repository(
 )
 
 go_repository(
-    name = "in_gopkg_errgo_v2",
-    importpath = "gopkg.in/errgo.v2",
-    sum = "h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=",
-    version = "v2.1.0",
-)
-
-go_repository(
     name = "in_gopkg_resty_v1",
     importpath = "gopkg.in/resty.v1",
     sum = "h1:CuXP0Pjfw9rOuY6EP+UvtNvt5DSqHpIxILZKT/quCZI=",
@@ -779,27 +688,6 @@ go_repository(
     importpath = "go.etcd.io/bbolt",
     sum = "h1:Z/90sZLPOeCy2PwprqkFa25PdkusRzaj9P8zm/KNyvk=",
     version = "v1.3.2",
-)
-
-go_repository(
-    name = "io_opencensus_go",
-    importpath = "go.opencensus.io",
-    sum = "h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=",
-    version = "v0.22.0",
-)
-
-go_repository(
-    name = "io_rsc_binaryregexp",
-    importpath = "rsc.io/binaryregexp",
-    sum = "h1:HfqmD5MEmC0zvwBuF187nq9mdnXjXsSivRiXN7SmRkE=",
-    version = "v0.2.0",
-)
-
-go_repository(
-    name = "org_golang_google_api",
-    importpath = "google.golang.org/api",
-    sum = "h1:2tJEkRfnZL5g1GeBUlITh/rqT5HG3sFcoVCUUxmgJ2g=",
-    version = "v0.6.0",
 )
 
 go_repository(
@@ -831,38 +719,10 @@ go_repository(
 )
 
 go_repository(
-    name = "org_golang_x_exp",
-    importpath = "golang.org/x/exp",
-    sum = "h1:OeRHuibLsmZkFj773W4LcfAGsSxJgfPONhr8cmO+eLA=",
-    version = "v0.0.0-20190510132918-efd6b22b2522",
-)
-
-go_repository(
-    name = "org_golang_x_image",
-    importpath = "golang.org/x/image",
-    sum = "h1:fqF3kMQ0tlBEpnfxavzOrjqW5gokBwllwOABYxETOMA=",
-    version = "v0.0.0-20190618124811-92942e4437e2",
-)
-
-go_repository(
     name = "org_golang_x_lint",
     importpath = "golang.org/x/lint",
     sum = "h1:XQyxROzUlZH+WIQwySDgnISgOivlhjIEwaQaJEJrrN0=",
     version = "v0.0.0-20190313153728-d0100b6bd8b3",
-)
-
-go_repository(
-    name = "org_golang_x_mobile",
-    importpath = "golang.org/x/mobile",
-    sum = "h1:H6DkDrMSuEE2MQR7DgGwkzbXSY1lvMpEN5MDE1bo/5U=",
-    version = "v0.0.0-20190607214518-6fa95d984e88",
-)
-
-go_repository(
-    name = "org_golang_x_mod",
-    importpath = "golang.org/x/mod",
-    sum = "h1:sfUMP1Gu8qASkorDVjnMuvgJzwFbTZSeXFiGBYAVdl4=",
-    version = "v0.1.0",
 )
 
 go_repository(
@@ -933,69 +793,6 @@ go_repository(
     importpath = "go.uber.org/zap",
     sum = "h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=",
     version = "v1.10.0",
-)
-
-go_repository(
-    name = "com_github_armon_go_radix",
-    importpath = "github.com/armon/go-radix",
-    sum = "h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=",
-    version = "v1.0.0",
-)
-
-go_repository(
-    name = "com_github_boltdb_bolt",
-    importpath = "github.com/boltdb/bolt",
-    sum = "h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=",
-    version = "v1.3.1",
-)
-
-go_repository(
-    name = "com_github_golang_dep",
-    importpath = "github.com/golang/dep",
-    sum = "h1:WfV5qbGwsBNUDhk+pfI6emWm7SdDFsnSWkqCMNG3BRs=",
-    version = "v0.5.4",
-)
-
-go_repository(
-    name = "com_github_jmank88_nuts",
-    importpath = "github.com/jmank88/nuts",
-    sum = "h1:3rHp+7YcvtkTPohGBA++MwneB9OlX/rpORvleiRivMQ=",
-    version = "v0.4.0",
-)
-
-go_repository(
-    name = "com_github_masterminds_semver",
-    importpath = "github.com/Masterminds/semver",
-    sum = "h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=",
-    version = "v1.5.0",
-)
-
-go_repository(
-    name = "com_github_masterminds_vcs",
-    importpath = "github.com/Masterminds/vcs",
-    sum = "h1:NL3G1X7/7xduQtA2sJLpVpfHTNBALVNSjob6KEjPXNQ=",
-    version = "v1.13.1",
-)
-
-go_repository(
-    name = "com_github_nightlyone_lockfile",
-    importpath = "github.com/nightlyone/lockfile",
-    sum = "h1:+2OJrU8cmOstEoh0uQvYemRGVH1O6xtO2oANUWHFnP0=",
-    version = "v0.0.0-20180618180623-0ad87eef1443",
-)
-
-go_repository(
-    name = "com_github_sdboyer_constext",
-    importpath = "github.com/sdboyer/constext",
-    sum = "h1:tnWWLf0nI2TI62Wd/ZOea4XYqE+y1sf2pdm+VItsc0c=",
-    version = "v0.0.0-20170321163424-836a14457353",
-)
-
-go_repository(
-    name = "org_golang_x_xerrors",
-    importpath = "golang.org/x/xerrors",
-    sum = "h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=",
-    version = "v0.0.0-20190717185122-a985d3407aa7",
 )
 
 go_repository(

--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -52,7 +52,8 @@ func WriteString(item string, value string) error {
 }
 
 func GetTime(item string, defaultValue time.Time) (t time.Time, err error) {
-	valueString, err := GetString(item, "1")
+	defaultString := fmt.Sprintf("%d", defaultValue.Unix())
+	valueString, err := GetString(item, defaultString)
 	if err != nil {
 		return t, err
 	}
@@ -80,7 +81,8 @@ func WriteTime(item string, value time.Time) error {
 }
 
 func GetInt(item string, defaultValue int) (i int, err error) {
-	valueString, err := GetString(item, "1")
+	defaultString := strconv.Itoa(defaultValue)
+	valueString, err := GetString(item, defaultString)
 	if err != nil {
 		return 0, err
 	}
@@ -95,6 +97,27 @@ func GetInt(item string, defaultValue int) (i int, err error) {
 
 func WriteInt(item string, value int) error {
 	valueString := strconv.Itoa(value)
+
+	return WriteString(item, valueString)
+}
+
+func GetBool(item string, defaultValue bool) (b bool, err error) {
+	defaultString := strconv.FormatBool(defaultValue)
+	valueString, err := GetString(item, defaultString)
+	if err != nil {
+		return false, err
+	}
+
+	b, err = strconv.ParseBool(valueString)
+	if err != nil {
+		return false, err
+	}
+
+	return b, nil
+}
+
+func WriteBool(item string, value bool) error {
+	valueString := strconv.FormatBool(value)
 
 	return WriteString(item, valueString)
 }

--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -80,14 +80,14 @@ func WriteTime(item string, value time.Time) error {
 	return WriteString(item, valueString)
 }
 
-func GetInt(item string, defaultValue int) (i int, err error) {
-	defaultString := strconv.Itoa(defaultValue)
+func GetInt(item string, defaultValue int64) (i int64, err error) {
+	defaultString := fmt.Sprintf("%d", defaultValue)
 	valueString, err := GetString(item, defaultString)
 	if err != nil {
 		return 0, err
 	}
 
-	i, err = strconv.Atoi(valueString)
+	i, err = strconv.ParseInt(valueString, 10, 64)
 	if err != nil {
 		return 0, err
 	}
@@ -95,8 +95,8 @@ func GetInt(item string, defaultValue int) (i int, err error) {
 	return i, nil
 }
 
-func WriteInt(item string, value int) error {
-	valueString := strconv.Itoa(value)
+func WriteInt(item string, value int64) error {
+	valueString := strconv.FormatInt(value, 10)
 
 	return WriteString(item, valueString)
 }

--- a/lib/console/BUILD.bazel
+++ b/lib/console/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     importpath = "github.com/nugget/phoebot/lib/console",
     visibility = ["//visibility:public"],
     deps = [
-        "//lib/config:go_default_library",
         "@com_github_seeruk_minecraft_rcon//rcon:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/lib/console/server.go
+++ b/lib/console/server.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/nugget/phoebot/lib/config"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -95,8 +93,6 @@ func (si *ServerInfo) GetPlayers() error {
 			si.Players = append(si.Players, strings.TrimSpace(p))
 		}
 	}
-
-	config.WriteInt("players", len(si.Players))
 
 	return nil
 }

--- a/lib/mcserver/BUILD.bazel
+++ b/lib/mcserver/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/nugget/phoebot/lib/mcserver",
     visibility = ["//visibility:public"],
     deps = [
+        "//lib/config:go_default_library",
         "//lib/ipc:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_tidwall_gjson//:go_default_library",

--- a/lib/mcserver/main.go
+++ b/lib/mcserver/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nugget/phoebot/lib/config"
 	"github.com/nugget/phoebot/lib/ipc"
 
 	"github.com/Tnze/go-mc/bot"
@@ -243,6 +244,8 @@ func (s *Server) Status() (ps PingStats, err error) {
 	ps.Protocol = gjson.Get(json, "verison.protocol").Int()
 
 	ps.PlayersOnline--
+
+	config.WriteInt("players", ps.PlayersOnline)
 
 	return ps, nil
 }

--- a/lib/products/BUILD.bazel
+++ b/lib/products/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/nugget/phoebot/lib/products",
     visibility = ["//visibility:public"],
     deps = [
+        "//lib/config:go_default_library",
         "//lib/db:go_default_library",
         "//lib/ipc:go_default_library",
         "//lib/phoelib:go_default_library",

--- a/lib/products/main.go
+++ b/lib/products/main.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/nugget/phoebot/lib/config"
 	"github.com/nugget/phoebot/lib/db"
 	"github.com/nugget/phoebot/lib/ipc"
 	"github.com/nugget/phoebot/lib/phoelib"
@@ -160,6 +161,13 @@ func Poller(class string, name string, interval int, fn models.LatestVersionFunc
 	}).Info("New Poller waiting for version")
 
 	for {
+		enabled, _ := config.GetBool("enable_product_poller", false)
+		if !enabled {
+			logrus.Trace("enable_product_poller config is false")
+			time.Sleep(time.Duration(300) * time.Second)
+			continue
+		}
+
 		maxVer, err := fn(p.Name)
 		if err != nil {
 			logrus.WithFields(logrus.Fields{

--- a/main.go
+++ b/main.go
@@ -345,7 +345,7 @@ func SignLoop(interval int) error {
 	for {
 		playerCount, err := config.GetInt("players", 0)
 
-		if playerCount <= 1 {
+		if playerCount == 0 {
 			logrus.WithFields(logrus.Fields{
 				"players": playerCount,
 			}).Trace("Skipping SignLoop")

--- a/main.go
+++ b/main.go
@@ -441,22 +441,11 @@ func processChatStream(s *mcserver.Server) {
 			}).Trace("onChatMsg Debug With")
 		}
 
-		class := mcserver.ChatMsgClass(c)
-
 		f := s.LogFields(logrus.Fields{
 			"event":     "processChatStream",
 			"translate": c.Translate,
-			"class":     class,
+			"class":     mcserver.ChatMsgClass(c),
 		})
-
-		switch class {
-		case "join":
-			si := console.ServerInfo{}
-			err := si.GetPlayers()
-			if err != nil {
-				logrus.WithError(err).Error("GetPlayers failure")
-			}
-		}
 
 		// Process in-game triggers
 		//
@@ -665,10 +654,8 @@ func main() {
 	go processAnnounceStream()
 	go processMojangStream()
 
-	if false {
-		go products.Poller("PaperMC", "paper", interval, papermc.LatestVersion)
-		go mojang.Poller(interval)
-	}
+	go products.Poller("PaperMC", "paper", interval, papermc.LatestVersion)
+	go mojang.Poller(interval)
 
 	go housekeeping(600)
 

--- a/products/mojang/BUILD.bazel
+++ b/products/mojang/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/nugget/phoebot/products/mojang",
     visibility = ["//visibility:public"],
     deps = [
+        "//lib/config:go_default_library",
         "//lib/db:go_default_library",
         "//lib/ipc:go_default_library",
         "//lib/phoelib:go_default_library",

--- a/products/mojang/main.go
+++ b/products/mojang/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nugget/phoebot/lib/config"
 	"github.com/nugget/phoebot/lib/db"
 	"github.com/nugget/phoebot/lib/ipc"
 	"github.com/nugget/phoebot/lib/phoelib"
@@ -234,12 +235,21 @@ func Poller(interval int) {
 	slew := rand.Intn(10)
 	interval = interval + slew
 
+	configFlag := fmt.Sprintf("enable_%s_poller", CLASS)
+
 	for {
-		logrus.WithField("interval", interval).Trace(fmt.Sprintf("Looping %s Poller", CLASS))
+		enabled, _ := config.GetBool(configFlag, false)
+		if !enabled {
+			logrus.Tracef("%s config is false", configFlag)
+			time.Sleep(time.Duration(300) * time.Second)
+			continue
+		}
+
+		logrus.WithField("interval", interval).Tracef("Looping %s Poller", CLASS)
 
 		err := SeekReleases()
 		if err != nil {
-			logrus.WithError(err).Error(fmt.Sprintf("%s SeekReleases failed", CLASS))
+			logrus.WithError(err).Errorf("%s SeekReleases failed", CLASS)
 		}
 		time.Sleep(time.Duration(interval) * time.Second)
 	}

--- a/products/serverpro/main.go
+++ b/products/serverpro/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nugget/phoebot/lib/config"
 	"github.com/nugget/phoebot/lib/ipc"
 	"github.com/nugget/phoebot/lib/products"
 	"github.com/nugget/phoebot/models"
@@ -191,7 +192,16 @@ func Poller(interval int) {
 	slew := rand.Intn(10)
 	interval = interval + slew
 
+	configFlag := fmt.Sprintf("enable_%s_poller", CLASS)
+
 	for {
+		enabled, _ := config.GetBool(configFlag, false)
+		if !enabled {
+			logrus.Tracef("%s config is false", configFlag)
+			time.Sleep(time.Duration(300) * time.Second)
+			continue
+		}
+
 		logrus.WithField("interval", interval).Debug(fmt.Sprintf("Looping %s Poller", CLASS))
 
 		err := UpdateAllProducts()


### PR DESCRIPTION
This PR adds support for `enable_product_poller` config items that control whether or not the bot will poll for new versions of the various configured products to report to Discord.

This closes issue #70 